### PR TITLE
fix initial state setup functionality

### DIFF
--- a/src/components/Home.js
+++ b/src/components/Home.js
@@ -19,7 +19,6 @@ class Home extends Component {
   };
 
   componentDidMount = () => {
-    this.props.fetchProfile();
     this.setState({
       ...this.state,
       username: localStorage.getItem('username')

--- a/src/components/Setup.js
+++ b/src/components/Setup.js
@@ -1,27 +1,27 @@
 import { useEffect } from 'react';
 import { connect } from 'react-redux';
 
-import { fetchCategories } from '../actions';
+import { fetchCategories, fetchProfile } from '../actions';
 
 // this is a component that we insert into the Root component which
 // can be used to load categories into our redux state when
 // users first authenticate
 const mapStateToProps = state => ({
-  haveCategories: state.categories.allIds.length > 0,
   haveProfile: state.profile.tier_name ? true : false
 });
 
 // Functional component with destrctured props, wrapped with redux's connect
 export default connect(
   mapStateToProps,
-  { fetchCategories }
-)(({ haveCategories, haveProfile, fetchCategories }) => {
+  { fetchCategories, fetchProfile }
+)(({ haveProfile, fetchProfile, fetchCategories }) => {
   // useEffect hook which will run onMount
   useEffect(() => {
-    if (!haveCategories && haveProfile) {
-      fetchCategories();
+    if (!haveProfile) {
+      fetchProfile().then(fetchCategories);
     }
-  }, [haveCategories, haveProfile, fetchCategories]);
+
+  }, [haveProfile, fetchCategories, fetchProfile]);
 
   return null;
 });


### PR DESCRIPTION
# Description

This PR moves more of the requests necessary for initial state into the setup component.  We noticed that if users went directly to certain routes, our user profiles wouldn't be requested.  These changes should address that.

Fixes # (issue)
User profiles not loading if users reloaded certain routes.

## Type of change

Please delete options that are not relevant.

- [x Bug fix (non-breaking change which fixes an issue)

## Change status
- [x] Complete, tested, ready to review and merge
- [ ] Complete, but not tested (may need new tests)
- [ ] Incomplete/work-in-progress, PR is for discussion/feedback

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

Tested via Brave Browser and redux devtools to ensure our profiles and categories were loading no matter the route a user first comes to.

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My code has been reviewed by at least one peer
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [x] There are no merge conflicts