### PR TITLE
add custom question wizard

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
     "cloudinary-react": "^1.1.0",
     "he": "^1.2.0",
     "react": "^16.8.6",
+    "react-albus": "^2.0.0",
     "react-dnd": "^7.4.5",
     "react-dnd-html5-backend": "^7.4.4",
     "react-dom": "^16.8.6",

--- a/src/actions/questions.js
+++ b/src/actions/questions.js
@@ -163,9 +163,10 @@ export const changeQuestion = (
   }
 };
 
-export const addCustomQuestion = question => ({
+export const addCustomQuestion = (normalizedQuestion, round_id) => ({
   type: ADD_CUSTOM_QUESTION,
-  payload: question
+  payload: normalizedQuestion,
+  round_id
 });
 
 export const deleteStateQuestion = (id, round_id) => ({

--- a/src/components/CustomQuestionForm.js
+++ b/src/components/CustomQuestionForm.js
@@ -1,6 +1,7 @@
 import React, { useState } from 'react';
 import { connect } from 'react-redux';
 import shortid from 'shortid';
+import { Wizard, Steps, Step } from 'react-albus';
 
 import { fetchNewRoundQuestions, addCustomQuestion } from '../actions';
 import { getAllCategories, getAllQuestionTypes } from '../reducers';
@@ -20,68 +21,198 @@ const CustomQuestionForm = ({
     text: '',
     round_id: roundId
   });
+  const [question, setQuestion] = useState(null);
+  const [answerFields, setAnswerFields] = useState({
+    is_correct: false,
+    text: ''
+  });
+  const [answers, setAnswers] = useState([]);
   const handleChanges = e => {
     setFields({ ...fields, [e.target.name]: e.target.value });
   };
-  const onSubmit = e => {
+
+  const handleAnswerChanges = e => {
+    setAnswerFields({
+      ...answerFields,
+      [e.target.name]:
+        e.target.type === 'checkbox' ? e.target.checked : e.target.value
+    });
+  };
+  const onQuestionSubmit = e => {
     e.preventDefault();
-    const question = {
+    setQuestion({
       ...fields,
       position,
       isCustom: true,
       id: shortid.generate(),
       round_id: roundId
-    };
-    addCustomQuestion(question);
+    });
   };
+
+  const onAnswerSubmit = e => {
+    e.preventDefault();
+    const answer = {
+      ...answerFields,
+      id: shortid.generate(),
+      question_id: question.id
+    };
+    setAnswers([...answers, answer]);
+    setAnswerFields({
+      is_correct: false,
+      text: ''
+    });
+  };
+
+  // onFinish, turn our questions nad answers into
+  // what looks like a normalized server response
+  // then clear our fields
+  const onFinish = e => {
+    const entities = {
+      answers: answers.reduce(
+        (accu, cur) => ({
+          ...accu,
+          [cur.id]: cur
+        }),
+        {}
+      ),
+      questions: {
+        [question.id]: {
+          ...question,
+          answers: answers.map(a => a.id)
+        }
+      }
+    };
+    const result = question.id;
+    addCustomQuestion({ entities, result }, question.round_id);
+    setAnswerFields({ is_correct: false, text: '' });
+    setAnswers([]);
+    setFields({
+      category_id: categories[0].id,
+      question_type_id: types[0].id,
+      text: '',
+      round_id: roundId
+    });
+    setQuestion(null);
+  };
+
   return (
-    <form onSubmit={onSubmit}>
-      {errorMsg && <div>{errorMsg}</div>}
-      <input
-        onChange={handleChanges}
-        type="text"
-        name="text"
-        value={fields.question}
-        autoComplete="off"
-      />
-      <select
-        name="category_id"
-        onChange={handleChanges}
-        value={fields.category_id}
-      >
-        {categories.map(c => (
-          <option value={c.id} key={`c${c.id}`}>
-            {c.name}
-          </option>
-        ))}
-      </select>
-      <select
-        name="difficulty"
-        onChange={handleChanges}
-        value={fields.difficulty}
-      >
-        <option value="easy">easy</option>
-        <option value="medium">medium</option>
-        <option value="hard">hard</option>
-      </select>
-      <select
-        name="question_type_id"
-        onChange={handleChanges}
-        value={fields.question_type_id}
-      >
-        <option
-          value={types.find(t => t.name.toLowerCase().indexOf('multiple')).id}
-        >
-          multiple choice
-        </option>
-        <option
-          value={types.find(t => t.name.toLowerCase().indexOf('boolean')).id}
-        >
-          true/false
-        </option>
-      </select>
-      <button type="submit">Add Question</button>
-    </form>
+    <>
+      <Wizard>
+        <Steps>
+          <Step
+            id="question"
+            render={({ next }) => (
+              <form
+                onSubmit={e => {
+                  onQuestionSubmit(e);
+                  next();
+                }}
+              >
+                {errorMsg && <div>{errorMsg}</div>}
+                Question Text:
+                <input
+                  onChange={handleChanges}
+                  type="text"
+                  name="text"
+                  value={fields.text}
+                  autoComplete="off"
+                />
+                <select
+                  name="category_id"
+                  onChange={handleChanges}
+                  value={fields.category_id}
+                >
+                  {categories.map(c => (
+                    <option value={c.id} key={`c${c.id}`}>
+                      {c.name}
+                    </option>
+                  ))}
+                </select>
+                <select
+                  name="difficulty"
+                  onChange={handleChanges}
+                  value={fields.difficulty}
+                >
+                  <option value="easy">easy</option>
+                  <option value="medium">medium</option>
+                  <option value="hard">hard</option>
+                </select>
+                <select
+                  name="question_type_id"
+                  onChange={handleChanges}
+                  value={fields.question_type_id}
+                >
+                  <option
+                    value={
+                      types.find(t => t.name.toLowerCase().indexOf('multiple'))
+                        .id
+                    }
+                  >
+                    multiple choice
+                  </option>
+                  <option
+                    value={
+                      types.find(t => t.name.toLowerCase().indexOf('boolean'))
+                        .id
+                    }
+                  >
+                    true/false
+                  </option>
+                </select>
+                <button type="submit">Add Question</button>
+              </form>
+            )}
+          />
+          <Step
+            id="answers"
+            render={({ previous, push }) => (
+              <>
+                <form onSubmit={onAnswerSubmit}>
+                  {question && <div>{question.text}</div>}
+                  {answers &&
+                    answers.map((a, idx) => (
+                      <div key={a.id}>
+                        {a.text}
+                        <button
+                          onClick={() =>
+                            setAnswers([
+                              ...answers.slice(0, idx),
+                              ...answers.slice(idx + 1)
+                            ])
+                          }
+                        >
+                          delete
+                        </button>
+                      </div>
+                    ))}
+                  Answer Text:
+                  <input
+                    onChange={handleAnswerChanges}
+                    type="text"
+                    name="text"
+                    value={answerFields.text}
+                    autoComplete="off"
+                  />
+                  Correct?
+                  <input
+                    name="is_correct"
+                    type="checkbox"
+                    checked={answerFields.is_correct}
+                    onChange={handleAnswerChanges}
+                  />
+                  <button type="submit">Add Answer</button>
+                </form>
+                <button onClick={previous}>back to question</button>
+                <button onClick={(e) => {
+                  onFinish(e);
+                  push("question");
+                }}>finish</button>
+              </>
+            )}
+          />
+        </Steps>
+      </Wizard>
+    </>
   );
 };
 

--- a/src/components/RoundDetails.js
+++ b/src/components/RoundDetails.js
@@ -97,7 +97,7 @@ class RoundDetails extends Component {
         <p>{this.props.round.game_id}</p>
         <p>{this.props.round.created_at}</p>
         <p>{this.props.round.updated_at}</p>
-        <ul style={{ width: 400 }}>
+        <ul>
           {this.props.round.questions.map((q, idx) => (
             <Question
               questionId={q}

--- a/src/reducers/answers.js
+++ b/src/reducers/answers.js
@@ -8,7 +8,8 @@ import {
   FETCH_GAME_SUCCESS,
   EDIT_QUESTION_SUCCESS,
   GET_NEW_ROUND_QUESTIONS_SUCCESS,
-  CHANGE_QUESTION_SUCCESS
+  CHANGE_QUESTION_SUCCESS,
+  ADD_CUSTOM_QUESTION
 } from '../actions/types';
 
 import { combineReducers } from 'redux';
@@ -32,6 +33,7 @@ const byId = (state = {}, action) => {
       return {
         ...action.payload.entities.answers
       };
+    case ADD_CUSTOM_QUESTION:
     case EDIT_QUESTION_SUCCESS:
     case CHANGE_QUESTION_SUCCESS:
     case GET_NEW_ROUND_QUESTIONS_SUCCESS:
@@ -61,6 +63,7 @@ const allIds = (state = [], action) => {
     case FETCH_ANSWERS_SUCCESS:
       return Object.keys(action.payload.entities.answers);
     case EDIT_QUESTION_SUCCESS:
+    case ADD_CUSTOM_QUESTION:
     case CHANGE_QUESTION_SUCCESS:
     case GET_NEW_ROUND_QUESTIONS_SUCCESS:
       return state.concat(

--- a/src/reducers/questions.js
+++ b/src/reducers/questions.js
@@ -62,13 +62,9 @@ const byId = (state = {}, action) => {
         [action.payload.result]:
           action.payload.entities.questions[action.payload.result]
       };
+    case ADD_CUSTOM_QUESTION:
     case ADD_QUESTION_SUCCESS:
       return addQuestion(state, action);
-    case ADD_CUSTOM_QUESTION:
-      return {
-        ...state,
-        [action.payload.id]: action.payload
-      };
     case DELETE_STATE_QUESTION:
     case DELETE_QUESTION_SUCCESS:
       const { [action.payload]: omit, ...nextState } = state;
@@ -115,11 +111,10 @@ const allIds = (state = [], action) => {
           a => state.indexOf(a) === -1
         )
       );
-    case ADD_CUSTOM_QUESTION:
-      return [...state, action.payload.id];
     case DELETE_STATE_QUESTION:
     case DELETE_QUESTION_SUCCESS:
       return state.filter(id => id !== action.payload);
+    case ADD_CUSTOM_QUESTION:
     case ADD_QUESTION_SUCCESS:
       return action.updateId
         ? [...state.filter(id => id !== action.updateId), action.payload.result]

--- a/src/reducers/round.js
+++ b/src/reducers/round.js
@@ -38,11 +38,6 @@ const dragDropQuestion = (round, { dragIndex, hoverIndex }) => {
 // reducer for a single round
 const round = (state, action) => {
   switch (action.type) {
-    case ADD_CUSTOM_QUESTION:
-      return {
-        ...state,
-        questions: [...state.questions, action.payload.id]
-      };
     case GET_NEW_ROUND_QUESTIONS_SUCCESS:
       // spread the new question ids into this round's questions
       return {
@@ -52,6 +47,7 @@ const round = (state, action) => {
     case DELETE_STATE_QUESTION:
     case DELETE_QUESTION_SUCCESS:
       return removeQuestion(state, action.payload);
+    case ADD_CUSTOM_QUESTION:
     case ADD_QUESTION_SUCCESS:
       return action.updateId
         ? {

--- a/src/reducers/rounds.js
+++ b/src/reducers/rounds.js
@@ -20,6 +20,7 @@ const byId = (state = {}, action) => {
   switch (action.type) {
     case GET_NEW_ROUND_QUESTIONS_SUCCESS:
     case ADD_QUESTION_SUCCESS:
+    case ADD_CUSTOM_QUESTION:
     case DELETE_QUESTION_SUCCESS:
     case DELETE_STATE_QUESTION:
       return action.round_id
@@ -34,7 +35,6 @@ const byId = (state = {}, action) => {
               action
             )
           };
-    case ADD_CUSTOM_QUESTION:
     case DRAG_DROP_QUESTION:
       return {
         ...state,


### PR DESCRIPTION
# Description

**New Dependency**: [react-albus](https://github.com/americanexpress/react-albus)
**Purpose**: Creating wizards easily.

This PR lets users add answers to their custom questions before adding them to redux state and marking the round dirty.

This seemed like a 2 step process, one of making the question, than another of making all the answers.

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)

## Change status
- [x] Complete, tested, ready to review and merge
- [ ] Complete, but not tested (may need new tests)
- [ ] Incomplete/work-in-progress, PR is for discussion/feedback

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

Tested via Brave Browser and redux devtools, making sure UI and state changes are as expected.

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] My code has been reviewed by at least one peer
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [x] There are no merge conflicts