### PR TITLE
deleteRound functionality from CreateGame view as well as saved game view

### DIFF
--- a/src/actions/rounds.js
+++ b/src/actions/rounds.js
@@ -72,11 +72,11 @@ export const editRound = (id, roundData) => async dispatch => {
   }
 };
 
-export const deleteRound = id => async dispatch => {
+export const deleteRound = (round_id, game_id) => async dispatch => {
   dispatch({ type: DELETE_ROUND_START });
   try {
-    const success = await serverHandshake(true).delete(`/rounds/${id}`);
-    dispatch({ type: DELETE_ROUND_SUCCESS, payload: success.data });
+    const success = await serverHandshake(true).delete(`/rounds/${round_id}`);
+    dispatch({ type: DELETE_ROUND_SUCCESS, payload: round_id, game_id });
     return success;
   } catch (error) {
     dispatch({ type: DELETE_ROUND_FAILURE, payload: error });

--- a/src/components/CreateGame.js
+++ b/src/components/CreateGame.js
@@ -4,7 +4,7 @@ import { connect } from 'react-redux';
 import { Link } from 'react-router-dom';
 import NewQuestionGetter from './NewQuestionGetter';
 
-import { fetchGame, addRound, updateGame } from '../actions';
+import { fetchGame, addRound, updateGame, deleteRound } from '../actions';
 
 class CreateGame extends Component {
   state = {
@@ -46,6 +46,10 @@ class CreateGame extends Component {
       });
   };
 
+  deleteRound = (round_id, game_id) => {
+    this.props.deleteRound(round_id, game_id);
+  };
+
   render() {
     if (!this.props.game) {
       return <div>Loading...</div>;
@@ -80,6 +84,9 @@ class CreateGame extends Component {
                 <Link to={`/rounds/${r}`}>
                   <button>Review Round</button>
                 </Link>
+                <button onClick={() => this.deleteRound(r, this.props.game.id)}>
+                  Delete Round
+                </button>
               </div>
             ))}
           </ul>
@@ -87,7 +94,7 @@ class CreateGame extends Component {
             {this.props.game.rounds.length >= this.props.roundLimit ? (
               <Link to="/billing">Upgrade to enable more rounds!</Link>
             ) : (
-              <button onClick={this.handleAddNewRound}>New Round</button>
+              <button onClick={this.handleAddNewRound}>Add Round</button>
             )}
           </div>
           <button onClick={() => this.updateGame()}>Save Game</button>
@@ -107,7 +114,8 @@ export default connect(
   {
     fetchGame,
     addRound,
-    updateGame
+    updateGame,
+    deleteRound
     // withRouter
   }
 )(CreateGame);

--- a/src/components/Game.js
+++ b/src/components/Game.js
@@ -3,7 +3,7 @@ import { connect } from 'react-redux';
 import { withRouter } from 'react-router-dom';
 import { Link } from 'react-router-dom';
 
-import { fetchGame, addRound } from '../actions';
+import { fetchGame, addRound, deleteRound } from '../actions';
 import Round from './Round';
 
 class Game extends Component {
@@ -26,6 +26,9 @@ class Game extends Component {
         this.props.fetchGame(this.props.match.params.id);
       });
   };
+  deleteRound = (round_id, game_id) => {
+    this.props.deleteRound(round_id, game_id);
+  };
 
   render() {
     if (!this.props.game || !this.props.game.rounds) {
@@ -40,6 +43,11 @@ class Game extends Component {
             {this.props.game.rounds.map(r => (
               <li key={`round${r}`}>
                 <Round roundId={r} />
+                <button
+                  onClick={() => this.props.deleteRound(r, this.props.game.id)}
+                >
+                  Delete Round
+                </button>
               </li>
             ))}
           </ul>
@@ -66,6 +74,7 @@ export default connect(
   {
     fetchGame,
     addRound,
-    withRouter
+    withRouter,
+    deleteRound
   }
 )(Game);

--- a/src/reducers/game.js
+++ b/src/reducers/game.js
@@ -1,10 +1,18 @@
 // reducer for a single game
-import { ADD_ROUND_SUCCESS } from '../actions/types';
+import { ADD_ROUND_SUCCESS, DELETE_ROUND_SUCCESS } from '../actions/types';
 
 const game = (state, action) => {
   switch (action.type) {
     case ADD_ROUND_SUCCESS:
       return { ...state, rounds: [...state.rounds, action.payload.result] };
+    case DELETE_ROUND_SUCCESS:
+      const newRounds = state.rounds.filter(
+        rounds => rounds !== action.payload
+      );
+      return {
+        ...state,
+        rounds: newRounds
+      };
 
     default:
       return state;

--- a/src/reducers/games.js
+++ b/src/reducers/games.js
@@ -5,7 +5,8 @@ import {
   ADD_GAME_SUCCESS,
   DELETE_GAME_SUCCESS,
   ADD_ROUND_SUCCESS,
-  UPDATE_GAME_DETAILS_SUCCESS
+  UPDATE_GAME_DETAILS_SUCCESS,
+  DELETE_ROUND_SUCCESS
 } from '../actions/types';
 import { combineReducers } from 'redux';
 import game from './game';
@@ -44,6 +45,12 @@ const byId = (state = {}, action) => {
         ...state,
         [action.payload.result]:
           action.payload.entities.games[action.payload.result]
+      };
+    case DELETE_ROUND_SUCCESS:
+      console.log('delete', action);
+      return {
+        ...state,
+        [action.game_id]: game(state[action.game_id], action)
       };
 
     default:

--- a/src/reducers/rounds.js
+++ b/src/reducers/rounds.js
@@ -9,7 +9,8 @@ import {
   ADD_CUSTOM_QUESTION,
   ADD_QUESTION_SUCCESS,
   DELETE_STATE_QUESTION,
-  DRAG_DROP_QUESTION
+  DRAG_DROP_QUESTION,
+  DELETE_ROUND_SUCCESS
 } from '../actions/types';
 
 import { combineReducers } from 'redux';
@@ -53,6 +54,10 @@ const byId = (state = {}, action) => {
         [action.payload.result]:
           action.payload.entities.rounds[action.payload.result]
       };
+    case DELETE_ROUND_SUCCESS:
+      const { [action.payload]: removed, ...newState } = state;
+      return newState;
+
     default:
       return state;
   }
@@ -72,6 +77,9 @@ const allIds = (state = [], action) => {
       return state.indexOf(action.payload.result) > -1
         ? state
         : [...state, action.payload.result];
+    case DELETE_ROUND_SUCCESS:
+      return state.filter(round => round !== action.payload.toString());
+
     default:
       return state;
   }


### PR DESCRIPTION
# Description
This pull request brings in the ability to delete rounds from both the 'create a game' view and the saved game view. After clicking delete round from either view, the round is deleted from database and state is updated to remove the round.
Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Change status
- [X] Complete, tested, ready to review and merge
- [ ] Complete, but not tested (may need new tests)
- [ ] Incomplete/work-in-progress, PR is for discussion/feedback

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [X] Test A: Running locally, user is able to delete rounds from database and redux state
- [ ] Test B

# Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [ ] My code has been reviewed by at least one peer
- [X] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [X] There are no merge conflicts