### PR TITLE
minor adjustments to Billing page styling

### DIFF
--- a/src/components/stripe/CheckoutForm.js
+++ b/src/components/stripe/CheckoutForm.js
@@ -68,13 +68,18 @@ class _CheckoutForm extends Component {
           togglePremium={this.togglePremiumPlan}
           tier={this.props.profile.tier_name}
         />
-        {this.state.basicPlan !== this.state.premiumPlan && (
+        <CircularProgress
+          basicPlan={this.state.basicPlan}
+          premiumPlan={this.state.premiumPlan}
+          stripe={this.props.stripe}
+        />
+        {/* {this.state.basicPlan !== this.state.premiumPlan && (
           <CircularProgress
             basicPlan={this.state.basicPlan}
             premiumPlan={this.state.premiumPlan}
             stripe={this.props.stripe}
           />
-        )}
+        )} */}
       </div>
     );
   }

--- a/src/components/stripe/CircularProgress.js
+++ b/src/components/stripe/CircularProgress.js
@@ -123,20 +123,24 @@ class CircularIntegration extends React.Component {
     return (
       <>
         <div className={classes.root}>
-          <ProgressDiv className={classes.wrapper}>
-            <Fab color="primary" className={buttonClassname}>
-              {success ? <CheckIcon /> : <PaymentIcon />}
-            </Fab>
-            {loading && (
-              <CircularProgress size={68} className={classes.fabProgress} />
-            )}
-          </ProgressDiv>
+          {(loading || success) && (
+            <ProgressDiv className={classes.wrapper}>
+              <Fab color="primary" className={buttonClassname}>
+                {success ? <CheckIcon /> : <PaymentIcon />}
+              </Fab>
+              {loading && (
+                <CircularProgress size={68} className={classes.fabProgress} />
+              )}
+            </ProgressDiv>
+          )}
           <ProgressDiv className={classes.wrapper}>
             <Button
               variant="contained"
               color="primary"
               className={buttonClassname}
-              disabled={loading}
+              disabled={
+                loading || this.props.basicPlan === this.props.premiumPlan
+              }
               onClick={this.upgradeTier}
             >
               Pay With Card


### PR DESCRIPTION
# Description

This pull request adjusts some functionality on the billing page. Previously there was a loader and a submit button which both looked like buttons one could press to submit payment. Now the loader is hidden until the payment is processing. Additionally, the submit payment button is disabled unless one of the two options (silver or gold) are selected. If both are selected the button will be visible but disabled.

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Change status
- [X] Complete, tested, ready to review and merge
- [ ] Complete, but not tested (may need new tests)
- [ ] Incomplete/work-in-progress, PR is for discussion/feedback

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [X] Test A: This change works as expected while working locally
- [ ] Test B

# Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [ ] My code has been reviewed by at least one peer
- [X] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [X] There are no merge conflicts