### PR TITLE
minor billing style changes to account for views on different screen sizes

### DIFF
--- a/src/components/stripe/CheckoutForm.js
+++ b/src/components/stripe/CheckoutForm.js
@@ -13,7 +13,7 @@ const createOptions = () => {
   return {
     style: {
       base: {
-        fontSize: '20px',
+        fontSize: '16px',
         color: '#424770',
         fontFamily: 'Open Sans, sans-serif',
         letterSpacing: '0.025em',

--- a/src/styles/billing.css.js
+++ b/src/styles/billing.css.js
@@ -9,6 +9,7 @@ export const Card = styled.div`
   padding: 2rem 4rem;
   border-radius: 1rem;
   margin: 8rem auto;
+  max-width: 700px;
 `;
 
 export const ProgressDiv = styled.div`


### PR DESCRIPTION
# Description

The only changes made on this pull request are to incorporate a max size on the card component on the billing page so that it does not get stretched out too far on a larger screen. Also font inside stripe input decreased so it will work on mobile, desktop and tablet views.

Fixes # (issue)
Fixes issue of text overlap inside stripe input on mobile views and being stretched too far on desktop views

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Change status
- [X] Complete, tested, ready to review and merge
- [ ] Complete, but not tested (may need new tests)
- [ ] Incomplete/work-in-progress, PR is for discussion/feedback

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [X] Test A: The desired effect is working on mobile, tablet and desktop views
- [ ] Test B

# Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [ ] My code has been reviewed by at least one peer
- [X] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [X] There are no merge conflicts