### PR TITLE
small fix to query questionTypes and categories again on login

### DIFF
--- a/src/components/Games.js
+++ b/src/components/Games.js
@@ -4,7 +4,7 @@ import { Link } from 'react-router-dom';
 
 import waitForLogin from './waitForLogin';
 import { getAllGames } from '../reducers';
-import { fetchGames, createNewGame } from '../actions';
+import { fetchGames, createNewGame, fetchCategories, fetchQuestionTypes } from '../actions';
 
 import { Container, Background, Title, Button } from '../styles/shared.css';
 import { GameList } from '../styles/games.css';
@@ -19,6 +19,8 @@ class Games extends Component {
 
   componentDidMount = () => {
     this.props.fetchGames();
+    this.props.fetchCategories();
+    this.props.fetchQuestionTypes();
     console.log(this.props.auth);
   };
 
@@ -79,6 +81,8 @@ export default waitForLogin(
     mapStateToProps,
     {
       fetchGames,
+      fetchCategories,
+      fetchQuestionTypes,
       createNewGame
     }
   )(Games)


### PR DESCRIPTION
# Description

We adjusted the golden path, and accidentally removed the step that gets questionTypes and categories from our backend.

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
## Change status
- [x] Complete, tested, ready to review and merge
- [ ] Complete, but not tested (may need new tests)
- [ ] Incomplete/work-in-progress, PR is for discussion/feedback

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Test A
- [ ] Test B

# Checklist:

- [x] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] My code has been reviewed by at least one peer
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [x] There are no merge conflicts